### PR TITLE
Replace Silex with HttpKernel Component

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -59,9 +59,11 @@ class Application extends Container
         $this->post($this['unfurl.app_prefix'], function (Request $request) {
             return $this[UnfurlController::class]($request);
         });
-
         $this->get($this['unfurl.app_prefix'], function (Request $request) {
             return $this[InfoController::class]($request);
+        });
+        $this->get('/favicon.ico', static function () {
+            return new Response('', 404);
         });
     }
 

--- a/src/ServiceProvider/HttpKernelServiceProvider.php
+++ b/src/ServiceProvider/HttpKernelServiceProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SlackUnfurl\ServiceProvider;
+
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+use Symfony\Component\HttpKernel\Controller\ControllerResolver;
+use Symfony\Component\HttpKernel\EventListener\RouterListener;
+use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\Routing\Matcher\UrlMatcher;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @see https://symfony.com/doc/current/4.4/http_kernel.html#a-full-working-example
+ */
+class HttpKernelServiceProvider implements ServiceProviderInterface
+{
+    public function register(Container $app): void
+    {
+        $app[RouteCollection::class] = new RouteCollection();
+        $app[Request::class] = Request::createFromGlobals();
+
+        $matcher = new UrlMatcher($app[RouteCollection::class], new RequestContext());
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new RouterListener($matcher, new RequestStack()));
+
+        $controllerResolver = new ControllerResolver();
+        $argumentResolver = new ArgumentResolver();
+
+        $app[HttpKernel::class] = new HttpKernel($dispatcher, $controllerResolver, new RequestStack(), $argumentResolver);
+
+        $app['dispatcher'] = $dispatcher;
+    }
+}

--- a/src/ServiceProvider/HttpKernelServiceProvider.php
+++ b/src/ServiceProvider/HttpKernelServiceProvider.php
@@ -22,6 +22,8 @@ class HttpKernelServiceProvider implements ServiceProviderInterface
 {
     public function register(Container $app): void
     {
+        $app['debug'] = false;
+
         $app[RouteCollection::class] = new RouteCollection();
         $app[Request::class] = Request::createFromGlobals();
 


### PR DESCRIPTION
This is based on an example from http-kernel documentation

- https://symfony.com/doc/current/4.4/http_kernel.html#a-full-working-example

This drops [setupErrorHandler](https://github.com/glensc/slack-unfurl/blob/v0.10.2/src/Application.php#L48-L57), as `error()` is complex to implement (need to duplicate quite some logic from Silex), and not really needed in this project.